### PR TITLE
Add SoMsg to interface

### DIFF
--- a/convey/doc.go
+++ b/convey/doc.go
@@ -24,6 +24,7 @@ type C interface {
 	FocusConvey(items ...interface{})
 
 	So(actual interface{}, assert assertion, expected ...interface{})
+	SoMsg(msg string, actual interface{}, assert assertion, expected ...interface{})
 	SkipSo(stuff ...interface{})
 
 	Reset(action func())


### PR DESCRIPTION
This is required otherwise users of the lib can't see the function.